### PR TITLE
Fix: fetch only the groups of the current user.

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,7 +1,7 @@
 class GroupsController < ApplicationController
   def index
-    # @groups = Group.all
-    @groups = Group
+    # @groups = current_user.groups
+    @groups = current_user.groups
       .select('groups.*, COALESCE(SUM(movements.amount), 0) as movements_sum')
       .left_joins(:movements)
       .group('groups.id')


### PR DESCRIPTION
- Fetch only the groups of the current user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the way groups are listed for users, now including a summary of movements within each group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->